### PR TITLE
fix: Restore eureka.instance.hostname code

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,3 +9,5 @@ eureka:
   client:
     register-with-eureka: false
     fetch-registry: false
+  instance:
+    hostname: localhost


### PR DESCRIPTION
- hostname을 명시하지 않을 시 discovery 서버만 띄울 때는 문제 없었으나, 다른 서버 등록 시 해당 코드가 없을 경우 호스트 정보를 찾지 못해 문제 발생하여 해당 코드 원복 issue: #6

## ✅ 구현된 기능
- eureka.instance.hostname 원복
---

## 🚨 리뷰 포인트
- 다른 서버 실행 시 discovery 서버에 오류 로그 없이 정상 등록 확인
<img width="1711" height="120" alt="image" src="https://github.com/user-attachments/assets/e3f8a5a7-c3cd-4ae9-b422-b7b0e0e34b52" />
